### PR TITLE
Files, Form Content, and Multi-Form Content Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,10 +285,6 @@ The following features are planned and will be coming down the line:
 1. Squashing some bugs. (please report any issues you find)
 1. More Content Type Support
 
-### Currently Missing
-
-1. FormType/MultiformType integration
-
 ### Feel free to contribute! Prerequisites:
 
 1. Git

--- a/internal/integration_tests/main.go
+++ b/internal/integration_tests/main.go
@@ -40,6 +40,10 @@ type ExamplePathStruct struct {
 	ExamplePathField string `json:"example_path_field" name:"param" required:"true" description:"Example path field"`
 }
 
+type ExampleFileModel struct {
+	ExampleFileField []byte `json:"example_file_field" required:"true" description:"Example file field"`
+}
+
 func main() {
 
 	authConfiguration := &swaggo.AuthenticationConfiguration{
@@ -156,6 +160,69 @@ func main() {
 			},
 		},
 	})
+
+	mux.HandleFunc("/some-endpoint/with-file", health, "", swaggo.RequestDetails{
+		Method: "POST",
+		Requests: []swaggo.RequestData{
+			{
+				Type: swaggo.BodySource,
+				Data: ExampleFileModel{
+					ExampleFileField: []byte{},
+				},
+			},
+		},
+	})
+
+	mux.HandleFunc("/form-endpoint", health, "", swaggo.RequestDetails{
+		Method: "POST",
+		Requests: []swaggo.RequestData{
+			{
+				Type: swaggo.BodySource,
+				Data: ExampleBodyStruct{
+					ExampleField:    "example",
+					ExampleIntField: 1,
+				},
+				ContentType: []string{"application/x-www-form-urlencoded"},
+			},
+		}},
+	)
+	mux.HandleFunc("/form-endpoint/with-file", health, "", swaggo.RequestDetails{
+		Method: "POST",
+		Requests: []swaggo.RequestData{
+			{
+				Type: swaggo.BodySource,
+				Data: ExampleFileModel{
+					ExampleFileField: []byte{},
+				},
+				ContentType: []string{"application/x-www-form-urlencoded"},
+			},
+		}},
+	)
+	mux.HandleFunc("/form-endpoint/multipart", health, "", swaggo.RequestDetails{
+		Method: "POST",
+		Requests: []swaggo.RequestData{
+			{
+				Type: swaggo.BodySource,
+				Data: ExampleBodyStruct{
+					ExampleField:    "example",
+					ExampleIntField: 1,
+				},
+				ContentType: []string{"multipart/form-data"},
+			},
+		}},
+	)
+	mux.HandleFunc("/form-endpoint/multipart-with-file", health, "", swaggo.RequestDetails{
+		Method: "POST",
+		Requests: []swaggo.RequestData{
+			{
+				Type: swaggo.BodySource,
+				Data: ExampleFileModel{
+					ExampleFileField: []byte{},
+				},
+				ContentType: []string{"multipart/form-data"},
+			},
+		}},
+	)
 
 	mux.OpenBrowser()
 

--- a/swaggo/models.go
+++ b/swaggo/models.go
@@ -9,12 +9,10 @@ import (
 type RequestDataSource string
 
 const (
-	FormDataSource         RequestDataSource = "formData"
-	QuerySource            RequestDataSource = "query"
-	PathSource             RequestDataSource = "path"
-	BodySource             RequestDataSource = "body"
-	MultiformContentSource RequestDataSource = "multipart/form-data"
-	HeaderSource           RequestDataSource = "header"
+	QuerySource  RequestDataSource = "query"
+	PathSource   RequestDataSource = "path"
+	BodySource   RequestDataSource = "body"
+	HeaderSource RequestDataSource = "header"
 )
 
 type Route struct {


### PR DESCRIPTION
- Contains functionality for files (byte slice/array in a payload will count as a file)
- Clears up form content using content type instead of the raw source, which did nothing


+semver: minor